### PR TITLE
bail if no ipaddress

### DIFF
--- a/src/domain_services/cloudflare/mod.rs
+++ b/src/domain_services/cloudflare/mod.rs
@@ -1,3 +1,10 @@
+/*
+https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-patch-dns-record
+
+PATCH Request
+Only update changed parameters
+*/
+
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::Request;
@@ -28,13 +35,6 @@ pub struct CloudflareRequestBody {
 pub struct CloudflareMinimalResponseBody {
     pub success: bool,
 }
-
-/*
-https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-patch-dns-record
-
-PATCH Request
-Only update changed parameters
-*/
 
 pub async fn update_domains(
     config: &Config,

--- a/src/domain_services/mod.rs
+++ b/src/domain_services/mod.rs
@@ -20,7 +20,6 @@ pub async fn update_domains(
 
     let mut domain_results = HashMap::<String, DomainResult>::new();
 
-    // add more services here
     #[cfg(feature = "dyndns2")]
     dyndns2::update_domains(config, prev_results, &mut domain_results, &ip_address).await;
 

--- a/src/domain_services/mod.rs
+++ b/src/domain_services/mod.rs
@@ -11,7 +11,7 @@ mod dyndns2;
 pub async fn update_domains(
     config: &Config,
     prev_results: &Result<UpdateIpResults, String>,
-    ip_service_result: &Result<IpServiceResult, String>,
+    ip_service_result: &IpServiceResult,
 ) -> Result<HashMap<String, DomainResult>, String> {
     let ip_address = match get_ip_address(prev_results, ip_service_result) {
         Ok(ip) => ip,
@@ -32,13 +32,12 @@ pub async fn update_domains(
 
 fn get_ip_address(
     prev_results: &Result<UpdateIpResults, String>,
-    ip_service_result: &Result<IpServiceResult, String>,
+    ip_service_result: &IpServiceResult,
 ) -> Result<String, String> {
-    if let Ok(ip_result) = ip_service_result {
-        if let Some(ip_addr) = &ip_result.ip_address {
-            return Ok(ip_addr.clone());
-        }
+    if let Some(ip_addr) = &ip_service_result.ip_address {
+        return Ok(ip_addr.clone());
     }
+
     if let Ok(prev_result) = prev_results {
         if let Some(ip_addr) = &prev_result.ip_service_result.ip_address {
             return Ok(ip_addr.clone());

--- a/src/ip_services/mod.rs
+++ b/src/ip_services/mod.rs
@@ -30,8 +30,8 @@ pub async fn fetch_service_results(
         Err(e) => return Err(e),
     };
 
+    // there could be json responses
     let ip_address = match response_type {
-        // there could be json responses
         _ => address_as_body::get_ip_address_from_body(&response_json).await,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,5 @@ async fn main() -> Result<(), String> {
     let domain_service_results =
         domain_services::update_domains(&config, &prev_results, &ip_service_result).await;
 
-    results::write_results_to_disk(
-        &config,
-        ip_service_result,
-        domain_service_results,
-    )
-    .await
+    results::write_results_to_disk(&config, ip_service_result, domain_service_results).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ async fn main() -> Result<(), String> {
 
     let prev_results = results::read_results_from_disk(&config).await;
 
-    let ip_service_result = ip_services::fetch_service_results(&config, &prev_results).await;
+    let ip_service_result = match ip_services::fetch_service_results(&config, &prev_results).await {
+        Ok(ip_result) => ip_result,
+        Err(e) => return Err(e),
+    };
 
     let domain_service_results =
         domain_services::update_domains(&config, &prev_results, &ip_service_result).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ async fn main() -> Result<(), String> {
     let domain_service_results =
         domain_services::update_domains(&config, &prev_results, &ip_service_result).await;
 
-    let results = results::UpdateIpResults::try_from(ip_service_result, domain_service_results);
-
-    results::write_results_to_disk(results, &config.results_filepath).await
+    results::write_results_to_disk(
+        &config.results_filepath,
+        ip_service_result,
+        domain_service_results,
+    )
+    .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), String> {
         domain_services::update_domains(&config, &prev_results, &ip_service_result).await;
 
     results::write_results_to_disk(
-        &config.results_filepath,
+        &config,
         ip_service_result,
         domain_service_results,
     )

--- a/src/toolkit/results.rs
+++ b/src/toolkit/results.rs
@@ -22,9 +22,6 @@ impl IpServiceResult {
     }
 }
 
-// DONT only SAVE errors. Save response.
-// If validated save save ip_address update and results
-
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct DomainResult {
     pub hostname: String,

--- a/src/toolkit/results.rs
+++ b/src/toolkit/results.rs
@@ -80,10 +80,11 @@ pub async fn read_results_from_disk(config: &Config) -> Result<UpdateIpResults, 
 }
 
 pub async fn write_results_to_disk(
-    results: Result<UpdateIpResults, String>,
     results_filepath: &PathBuf,
+    ip_service_result: IpServiceResult,
+    domain_service_results: Result<HashMap<String, DomainResult>, String>,
 ) -> Result<(), String> {
-    let ready_results = match results {
+    let ready_results = match UpdateIpResults::try_from(ip_service_result, domain_service_results) {
         Ok(rs) => rs,
         Err(e) => return Err(e),
     };

--- a/src/toolkit/results.rs
+++ b/src/toolkit/results.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
 use tokio::fs;
 
 use crate::toolkit::config::Config;
@@ -80,7 +79,7 @@ pub async fn read_results_from_disk(config: &Config) -> Result<UpdateIpResults, 
 }
 
 pub async fn write_results_to_disk(
-    results_filepath: &PathBuf,
+    config: &Config,
     ip_service_result: IpServiceResult,
     domain_service_results: Result<HashMap<String, DomainResult>, String>,
 ) -> Result<(), String> {
@@ -94,7 +93,7 @@ pub async fn write_results_to_disk(
         Err(e) => return Err(e.to_string()),
     };
 
-    if let Err(e) = fs::write(&results_filepath, json_str).await {
+    if let Err(e) = fs::write(&config.results_filepath, json_str).await {
         return Err(e.to_string());
     };
 

--- a/src/toolkit/results.rs
+++ b/src/toolkit/results.rs
@@ -53,12 +53,12 @@ pub struct UpdateIpResults {
 
 impl UpdateIpResults {
     pub fn try_from(
-        ip_service_result: Result<IpServiceResult, String>,
+        ip_service_result: IpServiceResult,
         domain_service_results: Result<HashMap<String, DomainResult>, String>,
     ) -> Result<UpdateIpResults, String> {
-        if let (Ok(ip_result), Ok(domain_results)) = (ip_service_result, domain_service_results) {
+        if let Ok(domain_results) = domain_service_results {
             return Ok(UpdateIpResults {
-                ip_service_result: ip_result,
+                ip_service_result: ip_service_result,
                 domain_service_results: domain_results,
             });
         }


### PR DESCRIPTION
If Ip address response fails, bail early. Don't update other address.

The goal is to drag the net forward.
If ip address is not found, bail.
If ip address found, update services if not already updated

Ip fetch could fail
-> Then domain updates could fail

But we don't want to do domain updates when we know the previous ip address but cannot confirm current ip address.